### PR TITLE
feat(pi-gen): auto mount usb

### DIFF
--- a/pi-gen/stage3/02-setup-usb/00-run-chroot.sh
+++ b/pi-gen/stage3/02-setup-usb/00-run-chroot.sh
@@ -7,7 +7,7 @@ mkdir -p /media/usb2
 # Define fstab entries
 entries=(
 	"/dev/sda1  /media/usb1  auto  nofail,x-systemd.automount,uid=1000,gid=1000,umask=022  0  0"
-	"/dev/sda1  /media/usb2  auto  nofail,x-systemd.automount,uid=1000,gid=1000,umask=022  0  0"
+	"/dev/sda2  /media/usb2  auto  nofail,x-systemd.automount,uid=1000,gid=1000,umask=022  0  0"
 )
 
 # Append each entry if not already present


### PR DESCRIPTION
This PR introduces a system to auto mount inserted usb drives as `/media/usb1` and `/media/usb2`